### PR TITLE
Handling for extreme case of same size objects

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -661,14 +661,11 @@ namespace Visual_filtering_referable_objects
                     break;
                 case "sí":
                     List<Shape> copy = speechEraser.AnswerYesToErase();
-                    if (copy.Count > 0)
-                    {
                         SaveCurrentShapes();
                         shapes = copy;
                         PaintShapes();
                         Button_Click(null, null);
                         CustomMessageBox.AddTextSystem("Vale.");
-                    }
                     break;
                 case "no":
                     if (speechEraser.AnswerNoToErase())


### PR DESCRIPTION
Adds handling for extreme cases of same size objects, such as when:
- The user wants to erase the most 'size' object, but they are all the same. Then the system asks the user if he wants to erase them all.
- The user wants to delete the 'size' objects of x shape, and there is an object that it has another iterator (not of that size), but still the same area of the last object of the iterator that indicates the size. Then we will trust the user sight and delete it.

Tested and working.

Also solves a bug in which the user could not answer yes to erase all shapes.